### PR TITLE
Add a "statement use" option

### DIFF
--- a/src/axiom_use.rs
+++ b/src/axiom_use.rs
@@ -134,13 +134,11 @@ pub(crate) fn verify_usage(sset: &Arc<SegmentSet>, usage: &mut UsageResult) {
 
 impl Database {
     /// Writes a `stmt_use` file to the given writer.
-    pub fn write_stmt_use<F>(
+    pub fn write_stmt_use(
         &self,
-        label_test: F,
+        label_test: impl Fn(&[u8]) -> bool,
         out: &mut impl std::io::Write,
     ) -> Result<(), std::io::Error>
-    where
-        F: Fn(&[u8]) -> bool,
     {
         time(&self.options.clone(), "stmt_use", || {
             let mut stmt_use_map = HashMap::default();

--- a/src/axiom_use.rs
+++ b/src/axiom_use.rs
@@ -138,8 +138,7 @@ impl Database {
         &self,
         label_test: impl Fn(&[u8]) -> bool,
         out: &mut impl std::io::Write,
-    ) -> Result<(), std::io::Error>
-    {
+    ) -> Result<(), std::io::Error> {
         time(&self.options.clone(), "stmt_use", || {
             let mut stmt_use_map = HashMap::default();
             let mut stmt_list = vec![];

--- a/src/axiom_use.rs
+++ b/src/axiom_use.rs
@@ -133,15 +133,26 @@ pub(crate) fn verify_usage(sset: &Arc<SegmentSet>, usage: &mut UsageResult) {
 }
 
 impl Database {
-    /// Writes a `axiom_use` file to the given writer.
-    pub fn write_axiom_use(&self, out: &mut impl std::io::Write) -> Result<(), std::io::Error> {
-        time(&self.options.clone(), "axiom_use", || {
-            let mut axiom_use_map = HashMap::default();
-            let mut axioms = vec![];
+    /// Writes a `stmt_use` file to the given writer.
+    pub fn write_stmt_use<F>(
+        &self,
+        label_test: F,
+        out: &mut impl std::io::Write,
+    ) -> Result<(), std::io::Error>
+    where
+        F: Fn(&[u8]) -> bool,
+    {
+        time(&self.options.clone(), "stmt_use", || {
+            let mut stmt_use_map = HashMap::default();
+            let mut stmt_list = vec![];
             for sref in self.statements().filter(|stmt| stmt.is_assertion()) {
                 let label = sref.label();
                 let mut usage = Bitset::new();
-                if sref.statement_type() == StatementType::Provable {
+                if label_test(label) {
+                    usage.set_bit(stmt_list.len());
+                    stmt_list.push(as_str(label));
+                    stmt_use_map.insert(label, usage);
+                } else if sref.statement_type() == StatementType::Provable {
                     let mut i = 1;
                     loop {
                         let tk = sref.proof_slice_at(i);
@@ -149,20 +160,16 @@ impl Database {
                         if tk == b")" {
                             break;
                         }
-                        if let Some(usage2) = axiom_use_map.get(tk) {
+                        if let Some(usage2) = stmt_use_map.get(tk) {
                             usage |= usage2
                         }
                     }
                     write!(out, "{}:", as_str(label))?;
                     for i in &usage {
-                        write!(out, " {}", axioms[i])?;
+                        write!(out, " {}", stmt_list[i])?;
                     }
                     writeln!(out)?;
-                    axiom_use_map.insert(label, usage);
-                } else if label.starts_with(b"ax-") {
-                    usage.set_bit(axioms.len());
-                    axioms.push(as_str(label));
-                    axiom_use_map.insert(label, usage);
+                    stmt_use_map.insert(label, usage);
                 }
             }
             Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,7 @@ pub use formula::Formula;
 pub use formula::FormulaRef;
 pub use formula::Label;
 pub use formula::Symbol;
+pub use parser::is_valid_label;
 pub use segment::Comparer;
 pub use segment_set::SourceInfo;
 pub use statement::as_str;

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,7 +160,7 @@ fn main() {
             let vals: Vec<_> = matches.values_of("stmt_use").unwrap().collect();
             let output_file_path = vals[0];
             let stmt_list: Vec<_> = vals[1].split(',').map(str::as_bytes).collect();
-            if !stmt_list.clone().into_iter().all(is_valid_label) {
+            if !stmt_list.iter().copied().all(is_valid_label) {
                 clap::Error::with_description(
                     "Expected list of labels as second argument to --stmt-use",
                     clap::ErrorKind::InvalidValue,

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use annotate_snippets::display_list::DisplayList;
 use clap::{clap_app, crate_version};
 use metamath_knife::database::{Database, DbOptions};
 use metamath_knife::diag::BibError;
+use metamath_knife::parser::is_valid_label;
 use metamath_knife::statement::StatementAddress;
 use metamath_knife::verify_markup::{Bibliography, Bibliography2};
 use metamath_knife::{as_str, SourceInfo};
@@ -21,12 +22,11 @@ fn positive_integer(val: String) -> Result<(), String> {
 }
 
 fn label_list(val: String) -> Result<(), String> {
-    val.chars()
-        .all(|c| {
-            c == ',' || (c.is_ascii() && c.is_alphanumeric()) || c == '-' || c == '_' || c == '.'
-        })
+    val.split(',')
+        .map(str::as_bytes)
+        .all(is_valid_label)
         .then_some(())
-        .ok_or("Expected list of Metamaths labels".to_string())
+        .ok_or("Expected list of labels".to_string())
 }
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -161,8 +161,11 @@ fn main() {
             let output_file_path = vals[0];
             let stmt_list: Vec<_> = vals[1].split(',').map(str::as_bytes).collect();
             if !stmt_list.clone().into_iter().all(is_valid_label) {
-                eprintln!("Expected list of labels as second argument to --stmt-use");
-                std::process::exit(1);
+                clap::Error::with_description(
+                    "Expected list of labels as second argument to --stmt-use",
+                    clap::ErrorKind::InvalidValue,
+                )
+                .exit();
             }
             File::create(output_file_path)
                 .and_then(|file| {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -759,7 +759,8 @@ fn collect_definitions(seg: &mut Segment) {
 }
 
 /// Metamath spec valid label characters are `[-._a-zA-Z0-9]`
-fn is_valid_label(label: &[u8]) -> bool {
+#[must_use]
+pub fn is_valid_label(label: &[u8]) -> bool {
     label
         .iter()
         .all(|&c| c == b'.' || c == b'-' || c == b'_' || c.is_ascii_alphanumeric())


### PR DESCRIPTION
As suggested by @GinoGiotto in [a comment in #3399](https://github.com/metamath/set.mm/pull/3399#issuecomment-1685310104), this adds an option to get direct of indirect usage of theorems, given by the list of their labels.
