### PR TITLE
Add handling for double underscores

### DIFF
--- a/src/comment_parser.rs
+++ b/src/comment_parser.rs
@@ -85,7 +85,7 @@ enum UnderscoreMode {
 #[inline]
 #[must_use]
 pub const fn is_text_escape(c: u8) -> bool {
-    matches!(c, b'`' | b'[' | b'~')
+    matches!(c, b'`' | b'[' | b'~' | b'_')
 }
 
 /// Returns true if this is a character that is escaped in [`CommentItem::MathToken`] fields,

--- a/src/comment_parser.rs
+++ b/src/comment_parser.rs
@@ -184,7 +184,7 @@ impl<'a> CommentParser<'a> {
         if self.pos == self.end_subscript {
             return UnderscoreMode::Italic;
         }
-        if let Some(c) = self.pos.checked_sub(1).map(|pos| self.buf.get(pos)).flatten() {
+        if let Some(c) = self.pos.checked_sub(1).and_then(|pos| self.buf.get(pos)) {
             if c.is_ascii_whitespace() || OPENING_PUNCTUATION.contains(c) {
                 return UnderscoreMode::Italic;
             }

--- a/src/comment_parser.rs
+++ b/src/comment_parser.rs
@@ -189,7 +189,18 @@ impl<'a> CommentParser<'a> {
         if !self.buf.get(self.pos + 1)?.is_ascii_alphanumeric() {
             return None;
         }
-        let end = (self.pos + 2) + self.buf[self.pos + 2..].iter().position(|&c| c == b'_')?;
+        let mut end = self.pos + 2;
+        loop {
+            if *self.buf.get(end)? == b'_' {
+                if self.buf.get(end + 1) == Some(&b'_') {
+                    end += 2
+                } else {
+                    break;
+                }
+            } else {
+                end += 1
+            }
+        }
         if !self.buf[end - 1].is_ascii_alphanumeric()
             || matches!(self.buf.get(end + 1), Some(c) if c.is_ascii_alphanumeric())
         {

--- a/src/comment_parser.rs
+++ b/src/comment_parser.rs
@@ -27,7 +27,7 @@ use crate::{statement::unescape, Span};
 pub enum CommentItem {
     /// A piece of regular text. The characters in the buffer at the given
     /// span should be interpreted literally, except for the escapes.
-    /// Use `unescape_text` to strip the text escapes `[`, `~`, and `` ` ``.
+    /// Use `unescape_text` to strip the text escapes `[`, `~`, `` ` ``, and `_`.
     /// Note that `[` can also appear unescaped.
     Text(Span),
     /// A paragraph break, caused by two or more consecutive newlines in the input.
@@ -47,11 +47,11 @@ pub enum CommentItem {
     /// Use `unescape_math` to strip the escape character `` ` ``.
     MathToken(Span),
     /// A label of an existing theorem. The `usize` points to the `~` character.
-    /// Use `unescape_text` to strip the text escapes `[`, `~`, and `` ` ``.
+    /// Use `unescape_text` to strip the text escapes `[`, `~`, `` ` ``, and `_`.
     /// Note that `[` and `~` can also appear unescaped.
     Label(usize, Span),
     /// A link to a web site URL. The `usize` points to the `~` character.
-    /// Use `unescape_text` to strip the text escapes `[`, `~`, and `` ` ``.
+    /// Use `unescape_text` to strip the text escapes `[`, `~`, `` ` ``, and `_`.
     /// Note that `[` and `~` can also appear unescaped.
     Url(usize, Span),
     /// The `<HTML>` keyword, which starts HTML mode

--- a/src/comment_parser_tests.rs
+++ b/src/comment_parser_tests.rs
@@ -97,12 +97,7 @@ fn test_italic() {
 /// Two underscores in a row are treated as normal text.
 #[test]
 fn test_double_underscore() {
-    check(
-        b"MINIMIZE__WITH",
-        &[
-            Text(Span::new(0, 14)),
-        ],
-    )
+    check(b"MINIMIZE__WITH", &[Text(Span::new(0, 14))])
 }
 
 #[test]

--- a/src/comment_parser_tests.rs
+++ b/src/comment_parser_tests.rs
@@ -196,6 +196,10 @@ fn edge_cases() {
         b"~</HTML>",
         &[Label(0, Span::new(1, 1)), Text(Span::new(1, 8))],
     );
+    check(
+        b"_a__b_",
+        &[StartItalic(0), Text(Span::new(1, 5)), EndItalic(5)],
+    );
 }
 
 #[test]

--- a/src/comment_parser_tests.rs
+++ b/src/comment_parser_tests.rs
@@ -94,6 +94,17 @@ fn test_italic() {
     );
 }
 
+/// Two underscores in a row are treated as normal text.
+#[test]
+fn test_double_underscore() {
+    check(
+        b"MINIMIZE__WITH",
+        &[
+            Text(Span::new(0, 14)),
+        ],
+    )
+}
+
 #[test]
 fn test_bib() {
     check(


### PR DESCRIPTION
This is to align with change done in metamath/metamath-exe#160, to handle cases discovered in metamath/set.mm#3389.

Before these changes, double underscores were treated as subscript. They are now correctly ignored and returned as a single span.

~~To be complete, in addition to these changes, the `unescape_text` function in `CommentItem` should also transform double underscores into single underscores. @digama0, what's your proposal for those?~~