### PR TITLE
Underscores in comment's Html

### DIFF
--- a/src/comment_parser_tests.rs
+++ b/src/comment_parser_tests.rs
@@ -212,6 +212,10 @@ fn test_label() {
         b"Visit ~http://example.com",
         &[Text(Span::new(0, 6)), Url(6, Span::new(7, 25))],
     );
+    check(
+        b"According to ~ https://en.wikipedia.org/wiki/Torsion_(algebra) , an element",
+        &[Text(Span::new(0, 13)), Url(13, Span::new(15, 62)), Text(Span::new(62, 75))],
+    );
 }
 
 #[test]

--- a/src/comment_parser_tests.rs
+++ b/src/comment_parser_tests.rs
@@ -214,7 +214,11 @@ fn test_label() {
     );
     check(
         b"According to ~ https://en.wikipedia.org/wiki/Torsion_(algebra) , an element",
-        &[Text(Span::new(0, 13)), Url(13, Span::new(15, 62)), Text(Span::new(62, 75))],
+        &[
+            Text(Span::new(0, 13)),
+            Url(13, Span::new(15, 62)),
+            Text(Span::new(62, 75)),
+        ],
     );
 }
 

--- a/src/verify_markup.rs
+++ b/src/verify_markup.rs
@@ -451,11 +451,7 @@ fn verify_markup_comment(
             CommentItem::Label(i, sp) | CommentItem::Url(i, sp) => {
                 ensure_space_before(buf, i, &mut diag);
                 ensure_space_after(buf, i, &mut diag);
-                check_uninterpreted_escapes(buf, sp, |c, d| {
-                    if c != b'_' {
-                        diag(d)
-                    }
-                });
+                check_uninterpreted_escapes(buf, sp, |_, d| diag(d));
                 check_uninterpreted_html(buf, sp, &mut diag);
                 if matches!(item, CommentItem::Label(..)) {
                     temp_buffer.clear();

--- a/src/verify_markup.rs
+++ b/src/verify_markup.rs
@@ -427,7 +427,7 @@ fn verify_markup_comment(
             CommentItem::Text(sp) => {
                 check_uninterpreted_escapes(buf, sp, |c, d| {
                     // Don't report on unescaped [ in regular text
-                    if c != b'[' {
+                    if c != b'[' && (in_html.is_none() || c != b'_') {
                         diag(d)
                     }
                 });

--- a/src/verify_markup.rs
+++ b/src/verify_markup.rs
@@ -451,7 +451,11 @@ fn verify_markup_comment(
             CommentItem::Label(i, sp) | CommentItem::Url(i, sp) => {
                 ensure_space_before(buf, i, &mut diag);
                 ensure_space_after(buf, i, &mut diag);
-                check_uninterpreted_escapes(buf, sp, |_, d| diag(d));
+                check_uninterpreted_escapes(buf, sp, |c, d| {
+                    if c != b'_' {
+                        diag(d)
+                    }
+                });
                 check_uninterpreted_html(buf, sp, &mut diag);
                 if matches!(item, CommentItem::Label(..)) {
                     temp_buffer.clear();


### PR DESCRIPTION
Originally opened because of #128 to avoid issuing a diagnostic in case a non-doubled underscore is found in an URL.

Changed into fixing the handling of underscores in HTML.

Fixes #131 