### PR TITLE
don't unescape `_` in labels/URLs

### DIFF
--- a/src/comment_parser.rs
+++ b/src/comment_parser.rs
@@ -73,13 +73,21 @@ pub enum CommentItem {
     BibTag(Span),
 }
 
-/// Returns true if this is a character that is escaped in [`CommentItem::Text`],
-/// [`CommentItem::Label`] and [`CommentItem::Url`] fields,
+/// Returns true if this is a character that is escaped in [`CommentItem::Text`] fields,
 /// meaning that doubled occurrences are turned into single occurrences.
 #[inline]
 #[must_use]
 pub const fn is_text_escape(c: u8) -> bool {
     matches!(c, b'`' | b'[' | b'~' | b'_')
+}
+
+/// Returns true if this is a character that is escaped in
+/// [`CommentItem::Label`] and [`CommentItem::Url`] fields,
+/// meaning that doubled occurrences are turned into single occurrences.
+#[inline]
+#[must_use]
+pub const fn is_label_escape(c: u8) -> bool {
+    matches!(c, b'`' | b'[' | b'~')
 }
 
 /// Returns true if this is a character that is escaped in [`CommentItem::MathToken`] fields,
@@ -92,9 +100,15 @@ pub const fn is_math_escape(c: u8) -> bool {
 
 impl CommentItem {
     /// Remove text escapes from a markup segment `buf`, generally coming from the
-    /// [`CommentItem::Text`], [`CommentItem::Label`], or [`CommentItem::Url`] fields.
+    /// [`CommentItem::Text`] field.
     pub fn unescape_text(buf: &[u8], out: &mut Vec<u8>) {
         unescape(buf, out, is_text_escape)
+    }
+
+    /// Remove text escapes from a markup segment `buf`, generally coming from the
+    /// [`CommentItem::Label`] or [`CommentItem::Url`] fields.
+    pub fn unescape_label(buf: &[u8], out: &mut Vec<u8>) {
+        unescape(buf, out, is_label_escape)
     }
 
     /// Remove math escapes from a markup segment `buf`, generally coming from the
@@ -142,9 +156,15 @@ impl<'a> CommentParser<'a> {
     }
 
     /// Remove text escapes from a markup segment `span`, generally coming from the
-    /// [`CommentItem::Text`], [`CommentItem::Label`], or [`CommentItem::Url`] fields.
+    /// [`CommentItem::Text`] field.
     pub fn unescape_text(&self, span: Span, out: &mut Vec<u8>) {
         CommentItem::unescape_text(span.as_ref(self.buf), out)
+    }
+
+    /// Remove text escapes from a markup segment `span`, generally coming from the
+    /// [`CommentItem::Label`] or [`CommentItem::Url`] fields.
+    pub fn unescape_label(&self, span: Span, out: &mut Vec<u8>) {
+        CommentItem::unescape_label(span.as_ref(self.buf), out)
     }
 
     /// Remove math escapes from a markup segment `span`, generally coming from the

--- a/src/comment_parser_tests.rs
+++ b/src/comment_parser_tests.rs
@@ -212,6 +212,10 @@ fn test_label() {
         b"Visit ~http://example.com",
         &[Text(Span::new(0, 6)), Url(6, Span::new(7, 25))],
     );
+    check(
+        b"test ~ https://a_b__c.com",
+        &[Text(Span::new(0, 5)), Url(5, Span::new(7, 25))],
+    );
 }
 
 #[test]


### PR DESCRIPTION
fixes #128, supercedes #129. Rather than turning off the diagnostic, the right solution is to not be undoubling `_` inside labels/URLs. This means that we now have three different undoubling functions, since the undoubling behavior is different between `Text`, `Label/Url` and `Math`. Some testing is required to double check that underscore undoubling does in fact not happen inside URLs in metamath-exe.