### PR TITLE
fix error formatting bug

### DIFF
--- a/src/diag.rs
+++ b/src/diag.rs
@@ -1108,7 +1108,8 @@ impl Diagnostic {
                 notes = &[
                     "This character has special meaning in this position, \
                     but it was not interpretable here.",
-                    "Use ~~ or [[ or `` or \\_\\_ if you mean to include the character literally"
+                    // Zero width space, see #136
+                    "Use ~~ or [[ or `` or _\u{200B}_ if you mean to include the character literally"
                 ];
                 ("Invalid escape character".into(), vec![(
                     AnnotationType::Warning,

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -1108,7 +1108,7 @@ impl Diagnostic {
                 notes = &[
                     "This character has special meaning in this position, \
                     but it was not interpretable here.",
-                    "Use ~~ or [[ or `` or __ if you mean to include the character literally"
+                    "Use ~~ or [[ or `` or \\__ if you mean to include the character literally"
                 ];
                 ("Invalid escape character".into(), vec![(
                     AnnotationType::Warning,

--- a/src/diag.rs
+++ b/src/diag.rs
@@ -1108,7 +1108,7 @@ impl Diagnostic {
                 notes = &[
                     "This character has special meaning in this position, \
                     but it was not interpretable here.",
-                    "Use ~~ or [[ or `` or \\__ if you mean to include the character literally"
+                    "Use ~~ or [[ or `` or \\_\\_ if you mean to include the character literally"
                 ];
                 ("Invalid escape character".into(), vec![(
                     AnnotationType::Warning,


### PR DESCRIPTION
As seen in https://github.com/metamath/set.mm/actions/runs/6345667560/job/17238038357?pr=3522 the "__" is interpreted as the markdown bold syntax, so this should be escaped

![image](https://github.com/metamath/metamath-knife/assets/58114641/d6fc3143-b5dc-40c9-a6df-afcd8532f7c7)

EDIT: This is kinda weird since there are no underscores at the end of the message...