### PR TITLE
grammar bugfixes

### DIFF
--- a/src/formula.rs
+++ b/src/formula.rs
@@ -753,14 +753,14 @@ impl<'a> Debug for FormulaRef<'a> {
     }
 }
 
-#[derive(Default)]
+/// A utility to build a formula.
+#[derive(Default, Debug)]
 pub(crate) struct FormulaBuilder {
     stack: Vec<NodeId>,
     variables: Bitset,
     tree: Tree<Label>,
 }
 
-/// A utility to build a formula.
 impl FormulaBuilder {
     pub(crate) fn from_formula(fmla: Formula) -> Self {
         let stack = vec![fmla.root];


### PR DESCRIPTION
Fixes #135 (or at least, that's the idea). I have a minimal example of the bug currently afflicting set.mm master:
```
  $c = class wff setvar -> ( ) |- + [ ] $.
  $( $j syntax 'setvar' 'class' 'wff'; syntax '|-' as 'wff'; $)
  $v x A B ph ps $.
  vx $f setvar x $.
  wph $f wff ph $.
  wps $f wff ps $.
  cA $f class A $.
  cB $f class B $.
  cv $a class x $.
  wn $a wff [ A ] $.
  wceq $a wff A = B $.
  wi $a wff ( ph -> ps ) $.
  cdif $a class ( A + B ) $.
  ax1 $a |- [ x ] $.
  ax2 $a |- ( x = x -> ph ) $.
```

The PR currently fixes the `ax1` bug, but the `ax2` bug is still not fixed. (Note the `cdif` axiom, which is not used but seems to muck up the grammar somehow.)

I have to say, I am really considering doing the parser again from first principles. There are way too many hacks in the current implementation and I feel like I'm just piling more on here, but I want to get set.mm green again before considering more complicated refactors.

cc: @tirix 