### PR TITLE
add const_ranges iterator

### DIFF
--- a/src/scopeck.rs
+++ b/src/scopeck.rs
@@ -124,6 +124,16 @@ pub struct VerifyExpr {
     pub tail: Box<[ExprFragment]>,
 }
 
+impl VerifyExpr {
+    /// Returns an iterator over runs of constants in the expression,
+    /// as references into the constant pool.
+    pub fn const_ranges(&self) -> impl Iterator<Item = Range<usize>> + '_ {
+        (self.tail.iter().map(|e| &e.prefix))
+            .chain(std::iter::once(&self.rump))
+            .cloned()
+    }
+}
+
 /// Representation of a hypothesis in a frame program.
 #[derive(Clone, Debug)]
 pub enum Hyp {


### PR DESCRIPTION
Used by mm-web-rs, a convenience method for getting the constants in an expression, including the `rump` at the end.