### PR TITLE
call grammar_pass before export_grammar_dot

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -226,6 +226,7 @@ fn main() {
 
         #[cfg(feature = "dot")]
         if matches.is_present("export_grammar_dot") {
+            db.grammar_pass();
             db.export_grammar_dot();
         }
 


### PR DESCRIPTION
It panics otherwise.