### PR TITLE
switch from lazy_static to std::sync::OnceLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
 dependencies = [
  "either",
 ]
@@ -183,7 +183,6 @@ dependencies = [
  "filetime",
  "fnv",
  "itertools",
- "lazy_static",
  "log",
  "regex",
  "tinyvec",

--- a/metamath-rs/Cargo.toml
+++ b/metamath-rs/Cargo.toml
@@ -11,8 +11,7 @@ categories.workspace = true
 edition = "2021"
 
 [dependencies]
-lazy_static = "1.4"
-itertools = "0.10"
+itertools = "0.12"
 filetime = "0.2"
 fnv = "1.0"
 regex = { version = "1.5", default-features = false, features = ["std", "perf"] }

--- a/metamath-rs/src/bit_set.rs
+++ b/metamath-rs/src/bit_set.rs
@@ -128,6 +128,11 @@ impl Bitset {
                 Some(bx) => bx.iter().all(|&word| word == 0),
             }
     }
+
+    /// Returns an iterator over the indices of set bits in the bitset.
+    pub fn iter(&self) -> BitsetIter<'_> {
+        self.into_iter()
+    }
 }
 
 impl<'a> BitOrAssign<&'a Bitset> for Bitset {

--- a/metamath-rs/src/comment_parser.rs
+++ b/metamath-rs/src/comment_parser.rs
@@ -14,9 +14,8 @@
 //! corresponding byte string in the file has to be unescaped before
 //! interpretation, using the [`CommentParser::unescape_text`] and
 //! [`CommentParser::unescape_math`] functions.
-use std::fmt::Display;
+use std::{fmt::Display, sync::OnceLock};
 
-use lazy_static::lazy_static;
 use regex::bytes::{CaptureMatches, Match, Regex, RegexSet};
 
 use crate::{statement::unescape, Span};
@@ -473,14 +472,15 @@ impl Discouragements {
     /// is discouraged.
     #[must_use]
     pub fn new(buf: &[u8]) -> Self {
-        lazy_static! {
-            static ref MODIFICATION: RegexSet = RegexSet::new([
+        static MODIFICATION: OnceLock<RegexSet> = OnceLock::new();
+        let modification = MODIFICATION.get_or_init(|| {
+            RegexSet::new([
                 r"\(Proof[ \n]+modification[ \n]+is[ \n]+discouraged\.\)",
-                r"\(New[ \n]+usage[ \n]+is[ \n]+discouraged\.\)"
+                r"\(New[ \n]+usage[ \n]+is[ \n]+discouraged\.\)",
             ])
-            .unwrap();
-        }
-        let m = MODIFICATION.matches(buf);
+            .unwrap()
+        });
+        let m = modification.matches(buf);
         Self {
             modification_discouraged: m.matched(0),
             usage_discouraged: m.matched(1),
@@ -532,17 +532,17 @@ impl<'a> ParentheticalIter<'a> {
     /// Construct a new parenthetical iterator given a segment buffer and a span in it.
     #[must_use]
     pub fn new(buf: &'a [u8], span: Span) -> Self {
-        lazy_static! {
-            static ref PARENTHETICALS: Regex = Regex::new(concat!(
+        static PARENTHETICALS: OnceLock<Regex> = OnceLock::new();
+        let parentheticals = PARENTHETICALS.get_or_init(|| {
+            Regex::new(concat!(
                 r"\((Contributed|Revised|Proof[ \r\n]+shortened)",
                 r"[ \r\n]+by[ \r\n]+([^,)]+),[ \r\n]+([0-9]{1,2}-[A-Z][a-z]{2}-[0-9]{4})\.\)|",
                 r"\((Proof[ \r\n]+modification|New[ \r\n]+usage)[ \r\n]+is[ \r\n]+discouraged\.\)",
             ))
-            .unwrap();
-        }
-
+            .unwrap()
+        });
         Self {
-            matches: PARENTHETICALS.captures_iter(span.as_ref(buf)),
+            matches: parentheticals.captures_iter(span.as_ref(buf)),
             off: span.start,
         }
     }

--- a/metamath-rs/src/verify_markup.rs
+++ b/metamath-rs/src/verify_markup.rs
@@ -22,10 +22,12 @@ use crate::util::{HashMap, HashSet};
 use crate::{Database, Span, StatementRef, StatementType};
 use regex::bytes::Regex;
 use std::ops::Range;
+use std::sync::OnceLock;
 
-lazy_static::lazy_static! {
-    static ref WINDOWS_RESERVED_NAMES: Regex =
-        Regex::new("(?i-u)^(?:CON|PRN|AUX|NUL|(?:COM|LPT)[1-9])$").unwrap();
+fn windows_reserved_names() -> &'static Regex {
+    static WINDOWS_RESERVED_NAMES: OnceLock<Regex> = OnceLock::new();
+    WINDOWS_RESERVED_NAMES
+        .get_or_init(|| Regex::new("(?i-u)^(?:CON|PRN|AUX|NUL|(?:COM|LPT)[1-9])$").unwrap())
 }
 
 impl Database {
@@ -69,7 +71,7 @@ impl Database {
                     stmt.address(),
                     Diagnostic::MMReservedLabel(stmt.label_span()),
                 ))
-            } else if WINDOWS_RESERVED_NAMES.is_match(stmt.label()) {
+            } else if windows_reserved_names().is_match(stmt.label()) {
                 diags.push((
                     stmt.address(),
                     Diagnostic::WindowsReservedLabel(stmt.label_span()),
@@ -421,12 +423,11 @@ fn verify_markup_comment(
     }
 
     fn check_uninterpreted_html(buf: &[u8], sp: Span, diag: &mut impl FnMut(Diagnostic)) {
-        lazy_static::lazy_static! {
-            static ref HTML: Regex = Regex::new("(?i-u)</?HTML>").unwrap();
-        }
+        static HTML: OnceLock<Regex> = OnceLock::new();
+        let html = HTML.get_or_init(|| Regex::new("(?i-u)</?HTML>").unwrap());
         let text = sp.as_ref(buf);
-        if HTML.is_match(text) {
-            if let Some(m) = HTML.find(text) {
+        if html.is_match(text) {
+            if let Some(m) = html.find(text) {
                 diag(Diagnostic::UninterpretedHtml(Span::new2(
                     sp.start + m.start() as u32,
                     sp.start + m.end() as u32,
@@ -542,13 +543,13 @@ impl Bibliography {
     /// Parse bibliography file data out of the given [`SourceInfo`], and put
     /// any parse errors in `diags`.
     pub fn parse<'a>(source: &'a SourceInfo, diags: &mut Vec<(&'a SourceInfo, BibError)>) -> Self {
-        lazy_static::lazy_static! {
-            static ref A_NAME: Regex =
-                #[allow(clippy::invalid_regex)] // https://github.com/rust-lang/rust-clippy/issues/10825
-                Regex::new("(?i-u)<a[[:space:]]name=['\"]?([^&>]*?)['\"]?>").unwrap();
-        }
+        static A_NAME: OnceLock<Regex> = OnceLock::new();
+        let a_name = A_NAME.get_or_init(|| {
+            #[allow(clippy::invalid_regex)] // https://github.com/rust-lang/rust-clippy/issues/10825
+            Regex::new("(?i-u)<a[[:space:]]name=['\"]?([^&>]*?)['\"]?>").unwrap()
+        });
         let mut bib = HashMap::default();
-        for captures in A_NAME.captures_iter(&source.text) {
+        for captures in a_name.captures_iter(&source.text) {
             let m = captures.get(0).unwrap();
             let sp = Span::new(m.start(), m.end());
             if let Some(sp2) = bib.insert(captures.get(1).unwrap().as_bytes().into(), sp) {


### PR DESCRIPTION
[`once_cell`](https://docs.rs/once_cell/latest/once_cell/) is preferred over `lazy_static`, and it was recently standardized as `std::sync::OnceLock` in rustc 1.70.