### PR TITLE
Fix UB from precondition violations caught in rust 1.78

### DIFF
--- a/metamath-rs/src/util.rs
+++ b/metamath-rs/src/util.rs
@@ -33,11 +33,7 @@ pub(crate) fn fast_extend<T: Copy>(vec: &mut Vec<T>, other: &[T]) {
     vec.reserve(other.len());
     unsafe {
         let len = vec.len();
-        short_copy(
-            other.as_ptr(),
-            vec.as_mut_ptr().add(len),
-            other.len(),
-        );
+        short_copy(other.as_ptr(), vec.as_mut_ptr().add(len), other.len());
         vec.set_len(len + other.len());
     }
 }

--- a/metamath-rs/src/util.rs
+++ b/metamath-rs/src/util.rs
@@ -34,8 +34,8 @@ pub(crate) fn fast_extend<T: Copy>(vec: &mut Vec<T>, other: &[T]) {
     unsafe {
         let len = vec.len();
         short_copy(
-            other.get_unchecked(0),
-            vec.get_unchecked_mut(len),
+            other.as_ptr(),
+            vec.as_mut_ptr().add(len),
             other.len(),
         );
         vec.set_len(len + other.len());


### PR DESCRIPTION
This is a workaround for the new Rust 1.78 precondition checks which made CI for #158 fail.