### PR TITLE
dump formulas as s-exprs

### DIFF
--- a/metamath-rs/src/grammar.rs
+++ b/metamath-rs/src/grammar.rs
@@ -1741,7 +1741,7 @@ impl StmtParse {
                 println!(
                     "{}: {}",
                     as_str(nset.statement_name(&sref)),
-                    formula.as_ref(db)
+                    formula.as_ref(db).as_sexpr()
                 );
             }
         }


### PR DESCRIPTION
Currently, `--dump-formula` dumps formulas pretty-printed to token sequences, which defeats the purpose of parsing them in the first place. This makes the command more useful by printing the output as a sexpr instead, so it is easier to see the actual parse tree that resulted.