### PR TITLE
--verify-parse-stmt does nothing

### DIFF
--- a/metamath-knife/src/main.rs
+++ b/metamath-knife/src/main.rs
@@ -161,11 +161,6 @@ fn main() {
             db.typesetting_pass();
         }
 
-        if cli.verify_parse_stmt {
-            db.stmt_parse_pass();
-            db.verify_parse_stmt();
-        }
-
         if cli.verify_usage {
             db.verify_usage_pass();
         }
@@ -224,6 +219,14 @@ fn main() {
         let mut count = db
             .render_diags(diags, |msg| println!("{}", r.render(msg)))
             .len();
+
+        if cli.verify_parse_stmt {
+            db.stmt_parse_pass();
+            let diags = db.verify_parse_stmt();
+            count += db
+                .render_diags(diags, |msg| println!("{}", r.render(msg)))
+                .len();
+        }
 
         #[cfg(feature = "verify_markup")]
         if cli.verify_markup {

--- a/metamath-rs/src/database.rs
+++ b/metamath-rs/src/database.rs
@@ -958,9 +958,10 @@ impl Database {
 
     /// Verify that printing the formulas of this database gives back the original formulas.
     /// Requires: [`Database::name_pass`], [`Database::stmt_parse_pass`]
-    pub fn verify_parse_stmt(&self) {
+    #[must_use]
+    pub fn verify_parse_stmt(&self) -> Vec<(StatementAddress, Diagnostic)> {
         time(&self.options, "verify_parse_stmt", || {
-            drop(self.stmt_parse_result().verify(self));
+            self.stmt_parse_result().verify(self)
         })
     }
 


### PR DESCRIPTION
Make it return a list of errors and print them, instead of just dropping the result and always reporting no errors.