### PR TITLE
Fix for #174, more parser checks and more parser tests

### DIFF
--- a/metamath-rs/src/diag.rs
+++ b/metamath-rs/src/diag.rs
@@ -145,6 +145,7 @@ pub enum Diagnostic {
     MissingLabel,
     MissingMarkupDef([bool; 3], Span),
     MissingProof(Span),
+    MissingSpaceAfterCommandToken(Span),
     MMReservedLabel(Span),
     NestedComment(Span, Span),
     NotActiveSymbol(TokenIndex),
@@ -183,6 +184,7 @@ pub enum Diagnostic {
     UnclosedBeforeInclude(StatementIndex),
     UnclosedCommandComment(Span),
     UnclosedCommandString(Span),
+    UnclosedCommand(Span),
     UnclosedComment(Span),
     UnclosedHtml(u32, u32),
     UnclosedInclude,
@@ -734,6 +736,12 @@ impl Diagnostic {
                 stmt,
                 *math_end,
             )]),
+            MissingSpaceAfterCommandToken(span) => ("Missing space after command token".into(), vec![(
+                Level::Error,
+                "A quoted command token must be followed by a space or a semicolon (;)".into(),
+                stmt,
+                *span,
+            )]),
             MMReservedLabel(span) => ("Reserved label".into(), vec![(
                 Level::Warning,
                 "Labels beginning with 'mm' are reserved for Metamath file names".into(),
@@ -1014,6 +1022,12 @@ impl Diagnostic {
             UnclosedCommandString(span) => ("Unclosed string".into(), vec![(
                 Level::Error,
                 "A string must be closed with ' or \"".into(),
+                stmt,
+                *span,
+            )]),
+            UnclosedCommand(span) => ("Unclosed command".into(), vec![(
+                Level::Error,
+                "A command must be closed with a semicolon (;)".into(),
                 stmt,
                 *span,
             )]),

--- a/metamath-rs/src/statement.rs
+++ b/metamath-rs/src/statement.rs
@@ -362,7 +362,7 @@ impl CommandToken {
         let buf = span.as_ref(buf);
         if buf.contains(&quote) {
             let mut out = vec![];
-            unescape(span.as_ref(buf), &mut out, |c| quote == c);
+            unescape(buf, &mut out, |c| quote == c);
             out.into()
         } else {
             Cow::Borrowed(buf)


### PR DESCRIPTION
Fixes #174 
Adds two more error checks when parsing `$t` and `$j` commands:
- checks that a command is properly closed with a semicolon,
- checks that a space or a semicolon must always follow a quoted command token (`String`).

Adds the corresponding tests, and more.