### PR TITLE
Check for unknown labels in usage commands

### DIFF
--- a/metamath-rs/src/usage_tests.rs
+++ b/metamath-rs/src/usage_tests.rs
@@ -1,4 +1,4 @@
-use crate::diag::Diagnostic::UsageViolation;
+use crate::diag::Diagnostic::{UnknownLabel, UsageViolation};
 use crate::grammar_tests::mkdb;
 use assert_matches::assert_matches;
 
@@ -9,7 +9,7 @@ ax-1 $a |- > a $.
 thm1 $p |- > a $= wa ax-1 $.
 $( $j usage 'thm1' avoids 'ax-1'; $)
 thm2 $p |- > a $= ( ax-1 ) AB $.
-$( $j usage 'thm2' avoids 'ax-1'; $)
+$( $j usage 'thm2' avoids 'ax-1' 'ax-unknown'; $)
 ";
 
 #[test]
@@ -19,7 +19,8 @@ fn test_usage() {
     let usage = db.verify_usage_pass();
     let diags = usage.diagnostics();
 
-    assert_eq!(diags.len(), 2);
+    assert_eq!(diags.len(), 3);
     assert_matches!(diags[0], (_, UsageViolation(..)));
     assert_matches!(diags[1], (_, UsageViolation(..)));
+    assert_matches!(diags[2], (_, UnknownLabel(..)));
 }


### PR DESCRIPTION
Because the `usage` command was checking the database in a single pass, it did not know about axioms after the current cursor, and was assuming that these axioms existed and were not used.
However, this has the side effect of not being able to report unknown labels in usage commands.

This PR fixes this, and reports unknown labels in usage commands.
One test added.

This is a follow-up of #175: Following that PR, a missing space between two `usage` labels like in `$j 'exel' avoids 'ax-10''ax-13';` will now be parsed as refering to `ax-10'ax-13` (doubled quote as escape). To be complete, the tool now needs to report this unknown label.