### PR TITLE
Avoid calling `Instant::now()` when timing disabled

### DIFF
--- a/metamath-rs/src/database.rs
+++ b/metamath-rs/src/database.rs
@@ -413,13 +413,15 @@ impl Default for Database {
 }
 
 pub(crate) fn time<R, F: FnOnce() -> R>(opts: &DbOptions, name: &str, f: F) -> R {
-    let now = Instant::now();
-    let ret = f();
     if opts.timing {
+        let now = Instant::now();
+        let ret = f();
         // no as_msecs :(
         println!("{} {}ms", name, (now.elapsed() * 1000).as_secs());
+        ret
+    } else {
+        f()
     }
-    ret
 }
 
 impl Drop for Database {


### PR DESCRIPTION
This fixes using the library in WebAssembly, which panics when `Instant::now()` is called.

https://github.com/rust-lang/rust/blob/1d55f7270dc6fda5c19da3f563e91165d07463c4/library/std/src/sys/pal/wasm/mod.rs#L36-L37

https://github.com/rust-lang/rust/blob/1d55f7270dc6fda5c19da3f563e91165d07463c4/library/std/src/sys/pal/unsupported/time.rs#L11-L14